### PR TITLE
Added additional attr and text predicate constructors for data.zip.xml

### DIFF
--- a/src/main/clojure/clojure/data/zip/xml.clj
+++ b/src/main/clojure/clojure/data/zip/xml.clj
@@ -24,6 +24,16 @@
   attribute named attrname whose value is attrval."
   [attrname attrval] (fn [loc] (= attrval (attr loc attrname))))
 
+(defn attr-in?
+  "Returns a query predicate that matches a node when it has an
+  attribute named attrname whose value is in attrset"
+  [attrname attrset] (fn [loc] (contains? attrset (attr loc attrname))))
+
+(defn attr-like?
+  "Returns a query predicate that matches a node when it has an
+  attribute named attrname whose value matches attrre"
+  [attrname attrre] (fn [loc] (not (nil? (re-matches attrre (attr loc attrname))))))
+
 (defn tag=
   "Returns a query predicate that matches a node when its is a tag
   named tagname."
@@ -46,6 +56,16 @@
   "Returns a query predicate that matches a node when its textual
   content equals s."
   [s] (fn [loc] (= (text loc) s)))
+
+(defn text-in?
+  "Returns a query predicate that matches a node when its textual
+  content is in textset"
+  [textset] (fn [loc] (contains? textset (text loc))))
+
+(defn text-like?
+  "Returns a query predicate that matches a node when its textual
+  content matches re"
+  [re] (fn [loc] (not (nil? (re-matches re (text loc)))))) 
 
 (defn seq-test
   "Returns a query predicate that matches a node when its xml content

--- a/src/test/clojure/clojure/data/zip/xml_test.clj
+++ b/src/test/clojure/clojure/data/zip/xml_test.clj
@@ -52,6 +52,12 @@
            '("2"))))
   (testing "with string shortcut"
     (is (= (xml-> atom1 :entry [:author :name "agriffis"] :id text)
+           '("2"))))
+  (testing "with text in"
+    (is (= (xml-> atom1 :entry [:author :name (text-in? #{"agriffis"})] :id text)
+           '("2"))))
+  (testing "with text like"
+    (is (= (xml-> atom1 :entry [:author :name (text-like? #".*iffi.*")] :id text)
            '("2")))))
 
 (deftest test-xml1->
@@ -64,6 +70,10 @@
 
 (deftest test-attribute-filtering
   (is (= (xml-> atom1 :link [(attr= :rel "alternate")] (attr :type))
+         '("text/html")))
+  (is (= (xml-> atom1 :link [(attr-in? :rel #{"alternate"})] (attr :type))
+         '("text/html")))
+  (is (= (xml-> atom1 :link [(attr-like? :rel #"alt.*")] (attr :type))
          '("text/html"))))
 
 ;; This was in the original code under a comment, but is fails


### PR DESCRIPTION
Added two attr predicates:

``` clojure
(attr-in? :the-attr #{"valid value 1" "valid value 2" "etc..."})
(attr-like? :the-attr #"[Aa] pattern.*)
```

And two symmetric text predicates:

``` clojure
(text-in? #{"valid value 1" "valid value 2" "etc..."})
(text-like? #"[Hh]ello .*")
```

Also updated the test suite to exercise each predicate constructor.
