### PR TITLE
Remove unnecenssary clojure.xml requirement from clojure.data.zip.xml

### DIFF
--- a/src/main/clojure/clojure/data/zip/xml.clj
+++ b/src/main/clojure/clojure/data/zip/xml.clj
@@ -9,8 +9,7 @@
 
 (ns clojure.data.zip.xml
   (:require [clojure.data.zip :as zf]
-            [clojure.zip :as zip]
-            [clojure.xml :as xml]))
+            [clojure.zip :as zip]))
 
 (declare xml->)
 


### PR DESCRIPTION
clojure.xml is not really used in clojure.data.zip.xml and the requirement prevents crossover compilation to cljs, as clojure.xml is not available in clojurescript.

All tests pass.
