### PR TITLE
Fix docstring ref to examples from zip-query.clj

### DIFF
--- a/src/main/clojure/clojure/data/zip/xml.clj
+++ b/src/main/clojure/clojure/data/zip/xml.clj
@@ -68,7 +68,7 @@
   strings to text=, and vectors to sub-queries that return true if
   they match.
 
-  See the footer of zip-query.clj for examples."
+  See xml_test.clj for examples."
   [loc & preds]
   (zf/mapcat-chain loc preds
                    #(cond (keyword? %) (tag= %)


### PR DESCRIPTION
Examples were moved to xml_test.clj in 2011