### PR TITLE
Add fix for selection of sub entries with the same name

### DIFF
--- a/src/main/clojure/clojure/data/zip/xml.clj
+++ b/src/main/clojure/clojure/data/zip/xml.clj
@@ -29,9 +29,9 @@
   named tagname."
   [tagname]
   (fn [loc]
-    (or (= tagname (:tag (zip/node loc)))
-        (filter #(and (zip/branch? %) (= tagname (:tag (zip/node %))))
-                 (zf/children-auto loc)))))
+    (or (seq (filter #(and (zip/branch? %) (= tagname (:tag (zip/node %))))
+                     (zf/children-auto loc)))
+        (= tagname (:tag (zip/node loc))))))
 
 (defn text
   "Returns the textual contents of the given location, similar to

--- a/src/test/clojure/clojure/data/zip/xml_test.clj
+++ b/src/test/clojure/clojure/data/zip/xml_test.clj
@@ -98,3 +98,12 @@
 
 (deftest dzip-3-second-node
   (is (= (xml-> atom2 :foo text) '("bar"))))
+
+(def atom3 (parse-str "<root><foo><bar>outer</bar>
+<foo><bar>inner</bar></foo></foo></root>"))
+
+(deftest dzip-6-outer-bar
+  (is (= (xml-> atom3 :root :foo :bar text) '("outer"))))
+
+(deftest dzip-6-inner-bar
+  (is (= (xml-> atom3 :root :foo :foo :bar text) '("inner"))))


### PR DESCRIPTION
Because the current element was checked before its children,
equally named children were never selected. By swapping the
order of the check, this problem is fixed now.